### PR TITLE
Poll Voting Efficiency Fix

### DIFF
--- a/polls.php
+++ b/polls.php
@@ -916,8 +916,7 @@ if($mybb->input['action'] == "vote" && $mybb->request_method == "post")
 
 	$poll['timeout'] = $poll['timeout']*60*60*24;
 
-	$query = $db->simple_select("threads", "*", "poll='".(int)$poll['pid']."'");
-	$thread = $db->fetch_array($query);
+	$thread = get_thread($poll['tid']);
 
 	if(!$thread || $thread['visible'] == 0)
 	{


### PR DESCRIPTION
Removes a query against the non-indexed `poll` column in the `threads` table in favor of get_thread() using the poll tid.